### PR TITLE
[Feature] Introduces `--short-class` and minor fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "sethphat/eloquent-docs",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Generate PHPDoc scope for your Eloquent models",
     "type": "library",
     "require": {

--- a/src/Commands/EloquentDocsGeneratorCommand.php
+++ b/src/Commands/EloquentDocsGeneratorCommand.php
@@ -81,6 +81,8 @@ class EloquentDocsGeneratorCommand extends Command
      * @return void
      *
      * @throws \Symfony\Component\Process\Exception\ProcessSignaledException
+     *
+     * @codeCoverageIgnore Can't be covered so better to ignore
      */
     protected function installDependencies()
     {

--- a/src/Commands/EloquentDocsGeneratorCommand.php
+++ b/src/Commands/EloquentDocsGeneratorCommand.php
@@ -16,7 +16,7 @@ use Symfony\Component\Process\Process;
 #[AsCommand(name: 'eloquent:phpdoc')]
 class EloquentDocsGeneratorCommand extends Command
 {
-    protected $signature = 'eloquent:phpdoc {model} {--write}';
+    protected $signature = 'eloquent:phpdoc {model} {--write} {--short-class}';
     protected $description = '[SethPhat/EloquentDocs] Generate PHPDoc scope for your Eloquent Model';
 
     private Composer $composer;
@@ -48,6 +48,9 @@ class EloquentDocsGeneratorCommand extends Command
         $shouldWrite = (bool) $this->option('write');
 
         $generatedDocs = $generatePhpDocService->setModel(new $modelClass())
+            ->setOptions([
+                'useShortClass' => (bool) $this->option('short-class'),
+            ])
             ->generate();
 
         $this->info('====== Start PHPDOC scope of ' . $modelClass);

--- a/src/Services/GeneratePhpDocService.php
+++ b/src/Services/GeneratePhpDocService.php
@@ -21,6 +21,8 @@ class GeneratePhpDocService
 
     protected Model $model;
 
+    protected array $options = [];
+
     public function __construct(protected Application $laravel)
     {
     }
@@ -32,6 +34,18 @@ class GeneratePhpDocService
         return $this;
     }
 
+    public function setOptions(array $options): self
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
+    /**
+     * Generate phpDoc
+     *
+     * @return string
+     */
     public function generate(): string
     {
         $phpDocStr = '/**';
@@ -42,7 +56,7 @@ class GeneratePhpDocService
              */
             $generator = $this->laravel->make($generatorClass);
 
-            $phpDocStr .= $generator->generate($this->model);
+            $phpDocStr .= $generator->generate($this->model, $this->options);
         }
 
         $phpDocStr .= "\n*/";

--- a/src/Services/Generators/AccessorsGenerator.php
+++ b/src/Services/Generators/AccessorsGenerator.php
@@ -18,7 +18,7 @@ class AccessorsGenerator implements PhpDocGeneratorContract
         self::TYPE_ATTRIBUTE => '%s* @property %s %s',
     ];
 
-    public function generate(Model $model): string
+    public function generate(Model $model, array $options = []): string
     {
         $phpDocStr = "\n*\n* === Accessors/Attributes ===";
 
@@ -26,6 +26,8 @@ class AccessorsGenerator implements PhpDocGeneratorContract
         if ($virtualAttributes->isEmpty()) {
             return '';
         }
+
+        $isUseShortClass = $options['useShortClass'] ?? false;
 
         foreach ($virtualAttributes as $virtualAttribute) {
             $template = static::TEMPLATES[$virtualAttribute['cast']];
@@ -35,10 +37,19 @@ class AccessorsGenerator implements PhpDocGeneratorContract
                 $template = static::TEMPLATES[static::TYPE_ACCESSOR];
             }
 
+            $returnType = $virtualAttribute['returnType'];
+            if (class_exists($returnType)) {
+                if ($isUseShortClass) {
+                    $returnType = class_basename($returnType) . '|null';
+                } else{
+                    $returnType = '\\' . $returnType . '|null';
+                }
+            }
+
             $phpDocStr .= sprintf(
                 $template,
                 "\n",
-                $virtualAttribute['returnType'],
+                $returnType,
                 '$' . $virtualAttribute['name']
             );
         }

--- a/src/Services/Generators/ColumnsGenerator.php
+++ b/src/Services/Generators/ColumnsGenerator.php
@@ -59,7 +59,7 @@ class ColumnsGenerator implements PhpDocGeneratorContract
             // would be string if you don't add 'casts'
             'date', 'datetime', 'timestamp', 'time', 'year' => $this->hasDateCasting($columm->getName())
                 ? '\Carbon\Carbon'
-                : '\Carbon\Carbon|string',
+                : 'string',
 
             'char', 'string', 'varchar',
             'text', 'tinytext', 'mediumtext',

--- a/src/Services/Generators/ColumnsGenerator.php
+++ b/src/Services/Generators/ColumnsGenerator.php
@@ -18,7 +18,7 @@ class ColumnsGenerator implements PhpDocGeneratorContract
         $this->schema = $databaseConnection->getDoctrineSchemaManager();
     }
 
-    public function generate(Model $model): string
+    public function generate(Model $model, array $options = []): string
     {
         $this->model = $model;
         $columns = $this->schema->listTableColumns($model->getTable());
@@ -59,7 +59,7 @@ class ColumnsGenerator implements PhpDocGeneratorContract
             // would be string if you don't add 'casts'
             'date', 'datetime', 'timestamp', 'time', 'year' => $this->hasDateCasting($columm->getName())
                 ? '\Carbon\Carbon'
-                : '\Carbon\Carbon|null',
+                : '\Carbon\Carbon|string',
 
             'char', 'string', 'varchar',
             'text', 'tinytext', 'mediumtext',

--- a/src/Services/Generators/PhpDocGeneratorContract.php
+++ b/src/Services/Generators/PhpDocGeneratorContract.php
@@ -10,8 +10,9 @@ interface PhpDocGeneratorContract
      * Generate the needful phpDoc
      *
      * @param Model $model
+     * @param array $options
      *
      * @return string
      */
-    public function generate(Model $model): string;
+    public function generate(Model $model, array $options = []): string;
 }

--- a/src/Services/Generators/RelationshipsGenerator.php
+++ b/src/Services/Generators/RelationshipsGenerator.php
@@ -45,7 +45,7 @@ class RelationshipsGenerator implements PhpDocGeneratorContract
                 '%s* @property-read %s%s %s',
                 "\n",
                 $relatedClassName,
-                $isManyRelation ? '[]|\Illuminate\Support\Collection' : '|null',
+                $isManyRelation ? '[]|\Illuminate\Database\Eloquent\Collection' : '|null',
                 '$' . $relationship['name']
             );
         }

--- a/src/Services/Generators/RelationshipsGenerator.php
+++ b/src/Services/Generators/RelationshipsGenerator.php
@@ -24,10 +24,11 @@ class RelationshipsGenerator implements PhpDocGeneratorContract
         'morphedByMany',
     ];
 
-    public function generate(Model $model): string
+    public function generate(Model $model, array $options = []): string
     {
         $phpDocStr = "\n*\n* === Relationships ===";
         $relationships = $this->getRelations($model);
+        $isUseShortClass = $options['useShortClass'] ?? false;
 
         if ($relationships->isEmpty()) {
             return '';
@@ -36,10 +37,14 @@ class RelationshipsGenerator implements PhpDocGeneratorContract
         foreach ($relationships as $relationship) {
             $isManyRelation = Str::contains($relationship['returnType'], 'Many', true);
 
+            $relatedClassName = $isUseShortClass
+                ? class_basename($relationship['related'])
+                : '\\' . $relationship['related'];
+
             $phpDocStr .= sprintf(
                 '%s* @property-read %s%s %s',
                 "\n",
-                '\\' .$relationship['related'],
+                $relatedClassName,
                 $isManyRelation ? '[]|\Illuminate\Support\Collection' : '|null',
                 '$' . $relationship['name']
             );

--- a/src/Services/Generators/TableGenerator.php
+++ b/src/Services/Generators/TableGenerator.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class TableGenerator implements PhpDocGeneratorContract
 {
-    public function generate(Model $model): string
+    public function generate(Model $model, array $options = []): string
     {
         return sprintf('%s* Table: %s', "\n", $model->getTable());
     }

--- a/tests/Features/EloquentDocsGeneratorCommandTest.php
+++ b/tests/Features/EloquentDocsGeneratorCommandTest.php
@@ -25,13 +25,26 @@ class EloquentDocsGeneratorCommandTest extends TestCase
             ->expectsOutputToContain('@property object|\stdClass $additional_payload')
             ->expectsOutputToContain('@property \Illuminate\Support\Collection $external_data')
             ->expectsOutputToContain('=== Relationships ===')
-            ->expectsOutputToContain('@property-read \SethPhat\EloquentDocs\Tests\Fixtures\EmailFixture[]|\Illuminate\Support\Collection $emails')
+            ->expectsOutputToContain('@property-read \SethPhat\EloquentDocs\Tests\Fixtures\EmailFixture[]|\Illuminate\Database\Eloquent\Collection $emails')
             ->expectsOutputToContain('@property-read \SethPhat\EloquentDocs\Tests\Fixtures\UserDetailFixture|null $userDetail')
             ->expectsOutputToContain('=== Accessors/Attributes ===')
             ->expectsOutputToContain('@property-read string $full_name')
             ->expectsOutputToContain('@property-read int $total_salary')
             ->expectsOutputToContain('@property mixed $first_name')
             ->expectsOutputToContain('@property-read mixed $last_name')
+            ->assertSuccessful()
+            ->execute();
+    }
+
+    public function testCommandWillRunAndShowUpThePhpDocsUseShortHandClassName()
+    {
+        $this->artisan('eloquent:phpdoc', [
+            'model' => UserFixture::class,
+            '--short-class' => 1,
+        ])
+            ->expectsOutputToContain('@property-read EmailFixture[]|\Illuminate\Database\Eloquent\Collection $emails')
+            ->expectsOutputToContain('@property-read UserDetailFixture|null $userDetail')
+            ->expectsOutputToContain('@property-read EmailFixture|null $last_email')
             ->assertSuccessful()
             ->execute();
     }

--- a/tests/Fixtures/UserFixture.php
+++ b/tests/Fixtures/UserFixture.php
@@ -52,6 +52,11 @@ class UserFixture extends Model
         return 0;
     }
 
+    public function getLastEmailAttribute(): EmailFixture
+    {
+        return new EmailFixture();
+    }
+
     /**
      * Get the user's first name.
      *


### PR DESCRIPTION
## Feature

`--short-class` will render the short class name (without the full namespace path).

Assuming everybody is registering the relationships like this way:

```php
public function articles(): HasMany
{
    return $this->hasMany(Article::class);
}
```

=> it will render: `*property-read Article[]|\Illuminate\Support\Collection $articles`

Limitation:
- It won't use the short class name for Collection & Carbon (it never knows if your class has already import those yet), there would be other approaches indeed, which can be waited.

## Fixes
- Date/datetime columns without `casts` now will be considered as `string` (avoid type mismatch while coding)
    - Always a good approach to add your own date/datetime columns to the `$casts` method
- Changed the `*many` relationships access type from `\Illuminate\Support\Collection` to `Illuminate\Database\Eloquent\Collection` 
    - EloquentCollection has some specific methods (eg: load) so you can use in your cases better
- `get*Attribute` that defined an exact `return type` now will be added correctly in the phpDoc