### PR TITLE
allow mariadb as the driverName but use the pdo_mysql driver for doctrine

### DIFF
--- a/src/Services/DoctrineManager.php
+++ b/src/Services/DoctrineManager.php
@@ -30,13 +30,13 @@ class DoctrineManager
         $driverName = config("database.connections.{$defaultDb}.driver");
 
         $configs = match ($driverName) {
-            'mysql', 'pgsql' => [
+            'mysql', 'mariadb', 'pgsql' => [
                 'dbname' => config("database.connections.{$defaultDb}.database"),
                 'user' => config("database.connections.{$defaultDb}.username"),
                 'password' => config("database.connections.{$defaultDb}.password"),
                 'host' => config("database.connections.{$defaultDb}.host"),
                 'port' => config("database.connections.{$defaultDb}.port"),
-                'driver' => 'pdo_' . $driverName,
+                'driver' => 'pdo_' . ($driverName === 'mariadb' ? 'mysql' : $driverName),
             ],
             'sqlite' => [
                 'driver' => 'pdo_' . $driverName,


### PR DESCRIPTION
hey,

laravel 11.x added a new mariadb driver.
this adds support for it.

references:
https://laravel.com/docs/11.x/upgrade#dedicated-mariadb-driver
https://github.com/laravel/framework/pull/50146