### PR TITLE
Generate PHPDocs for Scopes

### DIFF
--- a/src/Services/GeneratePhpDocService.php
+++ b/src/Services/GeneratePhpDocService.php
@@ -50,22 +50,16 @@ class GeneratePhpDocService
      */
     public function generate(): string
     {
-        $phpDocStr = '/**';
-
-        foreach (static::GENERATORS as $generatorClass) {
+        $phpDocStr = "/**\n "
+          . join("\n *\n ", array_filter(array_map(function (string $generatorClass): string {
             /**
              * @var PhpDocGeneratorContract $generator
              */
             $generator = $this->laravel->make($generatorClass);
 
-            $doc = $generator->generate($this->model, $this->options);
-            if ($doc) {
-              $phpDocStr .= "$doc\n *\n";
-            }
-        }
-
-        $phpDocStr .= "\n */";
-
+            return trim($generator->generate($this->model, $this->options));
+          }, static::GENERATORS), fn ($item) => !empty($item)))
+          . "\n */";
         return $phpDocStr;
     }
 }

--- a/src/Services/GeneratePhpDocService.php
+++ b/src/Services/GeneratePhpDocService.php
@@ -9,6 +9,7 @@ use SethPhat\EloquentDocs\Services\Generators\ColumnsGenerator;
 use SethPhat\EloquentDocs\Services\Generators\PhpDocGeneratorContract;
 use SethPhat\EloquentDocs\Services\Generators\RelationshipsGenerator;
 use SethPhat\EloquentDocs\Services\Generators\TableGenerator;
+use SethPhat\EloquentDocs\Services\Generators\ScopesGenerator;
 
 class GeneratePhpDocService
 {
@@ -17,6 +18,7 @@ class GeneratePhpDocService
         ColumnsGenerator::class,
         RelationshipsGenerator::class,
         AccessorsGenerator::class,
+        ScopesGenerator::class,
     ];
 
     protected Model $model;
@@ -56,10 +58,13 @@ class GeneratePhpDocService
              */
             $generator = $this->laravel->make($generatorClass);
 
-            $phpDocStr .= $generator->generate($this->model, $this->options);
+            $doc = $generator->generate($this->model, $this->options);
+            if ($doc) {
+              $phpDocStr .= "$doc\n *\n";
+            }
         }
 
-        $phpDocStr .= "\n*/";
+        $phpDocStr .= "\n */";
 
         return $phpDocStr;
     }

--- a/src/Services/Generators/AccessorsGenerator.php
+++ b/src/Services/Generators/AccessorsGenerator.php
@@ -20,7 +20,7 @@ class AccessorsGenerator implements PhpDocGeneratorContract
 
     public function generate(Model $model, array $options = []): string
     {
-        $phpDocStr = "\n*\n* === Accessors/Attributes ===";
+        $phpDocStr = "\n * === Accessors/Attributes ===";
 
         $virtualAttributes = $this->getVirtualAttributes($model);
         if ($virtualAttributes->isEmpty()) {

--- a/src/Services/Generators/ColumnsGenerator.php
+++ b/src/Services/Generators/ColumnsGenerator.php
@@ -27,7 +27,7 @@ class ColumnsGenerator implements PhpDocGeneratorContract
         }
 
         // columns
-        $phpDocStr = "\n*\n* === Columns ===";
+        $phpDocStr = "\n * === Columns ===";
         foreach ($columns as $column) {
             $phpDocStr .= sprintf(
                 '%s * @property %s %s',

--- a/src/Services/Generators/RelationshipsGenerator.php
+++ b/src/Services/Generators/RelationshipsGenerator.php
@@ -26,7 +26,7 @@ class RelationshipsGenerator implements PhpDocGeneratorContract
 
     public function generate(Model $model, array $options = []): string
     {
-        $phpDocStr = "\n*\n* === Relationships ===";
+        $phpDocStr = "\n * === Relationships ===";
         $relationships = $this->getRelations($model);
         $isUseShortClass = $options['useShortClass'] ?? false;
 

--- a/src/Services/Generators/ScopesGenerator.php
+++ b/src/Services/Generators/ScopesGenerator.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SethPhat\EloquentDocs\Services\Generators;
+
+use Illuminate\Database\Eloquent\Model;
+use ReflectionClass;
+use ReflectionMethod;
+
+class ScopesGenerator implements PhpDocGeneratorContract
+{
+    public function generate(Model $model, array $options = []): string
+    {
+        $phpDoc = "";
+        $className = class_basename($model);
+        $reflection = new ReflectionClass($model);
+
+        foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($this->isLocalScope($method)) {
+                // Remove 'scope' from method name and convert to camelCase
+                $scopeName = lcfirst(substr($method->getName(), 5));
+                $phpDoc .= " * @method static \\Illuminate\\Database\\Eloquent\\Builder<{$className}> {$scopeName}()\n";
+            }
+        }
+
+        if (!$phpDoc) {
+          return "";
+        }
+
+        return "\n * === Scopes ===\n$phpDoc";
+    }
+
+    private function isLocalScope(ReflectionMethod $method): bool
+    {
+        $methodName = $method->getName();
+        return str_starts_with($methodName, 'scope') && strlen($methodName) > 5;
+    }
+}

--- a/src/Services/Generators/ScopesGenerator.php
+++ b/src/Services/Generators/ScopesGenerator.php
@@ -26,7 +26,7 @@ class ScopesGenerator implements PhpDocGeneratorContract
           return "";
         }
 
-        return "\n * === Scopes ===\n$phpDoc";
+        return " * === Scopes ===\n$phpDoc";
     }
 
     private function isLocalScope(ReflectionMethod $method): bool

--- a/src/Services/Generators/ScopesGenerator.php
+++ b/src/Services/Generators/ScopesGenerator.php
@@ -2,9 +2,11 @@
 
 namespace SethPhat\EloquentDocs\Services\Generators;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use ReflectionClass;
 use ReflectionMethod;
+use ReflectionNamedType;
 
 class ScopesGenerator implements PhpDocGeneratorContract
 {
@@ -18,7 +20,31 @@ class ScopesGenerator implements PhpDocGeneratorContract
             if ($this->isLocalScope($method)) {
                 // Remove 'scope' from method name and convert to camelCase
                 $scopeName = lcfirst(substr($method->getName(), 5));
-                $phpDoc .= " * @method static \\Illuminate\\Database\\Eloquent\\Builder<{$className}> {$scopeName}()\n";
+                $args="";
+                $i = -1;
+                $args = join(", ", array_filter(array_map(function ($param) use (&$i) {
+                    $type = $param->getType();
+                    $typeDoc = "";
+                    $i += 1;
+                    print("$i: $param\n  $type\n");
+                    if ($type) {
+                        if ($type instanceof ReflectionNamedType && $type->getName() === Builder::class) {
+                            return null;
+                        }
+                        $typeDoc = "$type ";
+                    } else if ($i === 0) {
+                        // First argument is the query builder
+                        return null;
+                    }
+                    if ($param->isPassedByReference()) {
+                        $typeDoc .= "&";
+                    }
+                    if ($param->isVariadic()) {
+                        $typeDoc .= "...";
+                    }
+                    return $typeDoc . '$' . $param->getName();
+                }, $method->getParameters()), fn ($item) => !empty($item)));
+                $phpDoc .= " * @method static \\Illuminate\\Database\\Eloquent\\Builder<{$className}> {$scopeName}($args)\n";
             }
         }
 

--- a/tests/Units/Generators/ScopesGeneratorTest.php
+++ b/tests/Units/Generators/ScopesGeneratorTest.php
@@ -2,15 +2,32 @@
 
 namespace Tests\Units\Generators;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\TestCase;
 use SethPhat\EloquentDocs\Services\Generators\ScopesGenerator;
 
 class ScopesTestModel1 extends Model {
-    public function scopePopular($query)
+    public function scopePopular1(Builder $query, ...$args)
     {
         $query->where('votes', '>', 100);
     }
+
+    public function scopePopular2(Builder $query, array ...$args)
+    {
+        $query->where('votes', '>', 100);
+    }
+
+    public function scopeUnpopular(Builder $query, ?int $votes = null)
+    {
+        $query->where('votes', '<=', $votes);
+    }
+
+    public function scopeInactive(Builder $query, bool &$foo)
+    {
+      $query->where('status', '!=', 'active');
+    }
+
     public function scopeActive($query)
     {
         $query->where('status', '=', 'active');
@@ -37,8 +54,11 @@ class ScopesGeneratorTest extends TestCase
         print("phpdoc:\n$phpDoc");
 
         $this->assertStringContainsString('=== Scopes ===', $phpDoc);
-        $this->assertStringContainsString('@method static \Illuminate\Database\Eloquent\Builder<ScopesTestModel1> popular()', $phpDoc);
+        $this->assertStringContainsString('@method static \Illuminate\Database\Eloquent\Builder<ScopesTestModel1> popular1(...$args)', $phpDoc);
+        $this->assertStringContainsString('@method static \Illuminate\Database\Eloquent\Builder<ScopesTestModel1> popular2(array ...$args)', $phpDoc);
+        $this->assertStringContainsString('@method static \Illuminate\Database\Eloquent\Builder<ScopesTestModel1> unpopular(?int $votes)', $phpDoc);
         $this->assertStringContainsString('@method static \Illuminate\Database\Eloquent\Builder<ScopesTestModel1> active()', $phpDoc);
+        $this->assertStringContainsString('@method static \Illuminate\Database\Eloquent\Builder<ScopesTestModel1> inactive(bool &$foo)', $phpDoc);
     }
 
     public function testGenerateExcludesNonScopeMethods(): void

--- a/tests/Units/Generators/ScopesGeneratorTest.php
+++ b/tests/Units/Generators/ScopesGeneratorTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Units\Generators;
+
+use Illuminate\Database\Eloquent\Model;
+use PHPUnit\Framework\TestCase;
+use SethPhat\EloquentDocs\Services\Generators\ScopesGenerator;
+
+class ScopesTestModel1 extends Model {
+    public function scopePopular($query)
+    {
+        $query->where('votes', '>', 100);
+    }
+    public function scopeActive($query)
+    {
+        $query->where('status', '=', 'active');
+    }
+}
+
+class ScopesTestModel2 extends Model {
+    public function nonScopeMethod()
+    {
+        return 'This is not a scope';
+    }
+}
+
+class ScopesGeneratorTest extends TestCase
+{
+    public function testGenerateIncludesLocalScopes(): void
+    {
+
+        $model = new ScopesTestModel1();
+
+        $generator = new ScopesGenerator();
+        $phpDoc = $generator->generate($model, []);
+
+        print("phpdoc:\n$phpDoc");
+
+        $this->assertStringContainsString('=== Scopes ===', $phpDoc);
+        $this->assertStringContainsString('@method static \Illuminate\Database\Eloquent\Builder<ScopesTestModel1> popular()', $phpDoc);
+        $this->assertStringContainsString('@method static \Illuminate\Database\Eloquent\Builder<ScopesTestModel1> active()', $phpDoc);
+    }
+
+    public function testGenerateExcludesNonScopeMethods(): void
+    {
+        $model = new ScopesTestModel2();
+
+        $generator = new ScopesGenerator();
+        $phpDoc = $generator->generate($model, []);
+
+        $this->assertStringNotContainsString('=== Scopes ===', $phpDoc);
+        $this->assertStringNotContainsString('@method static \Illuminate\Database\Eloquent\Builder<ScopesTestModel2> nonScopeMethod()', $phpDoc);
+    }
+}


### PR DESCRIPTION
Took a crack at attempting to resolve #25.

**Note:** also adjusts spacing before `*` in docblocks so that the `*`s are aligned. Should fix this issue:
<img width="139" alt="image" src="https://github.com/user-attachments/assets/7fec9308-80b3-4dff-8621-398c491b3d36" />

